### PR TITLE
ci: Update vercel action to deploy pull requests

### DIFF
--- a/.github/workflows/vercel-deploy.yml
+++ b/.github/workflows/vercel-deploy.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+  pull_request:
   workflow_dispatch:
 
 jobs:
@@ -19,4 +20,5 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           vercel-org-id: ${{ secrets.VERCEL_ORG_ID }}
           vercel-project-id: ${{ secrets.VERCEL_PROJECT_ID }}
-          vercel-args: --prod
+          # use --prod if it is a push to main, otherwise it is a preview
+          vercel-args: ${{ github.event_name != 'pull_request' && '--prod' || '' }}


### PR DESCRIPTION
This github action is necessary instead of Vercel build since Vercel does not ignore the images directory when doing automatic deployments.